### PR TITLE
feat(cv_model): allow generate function to return pdf bytes in addition to saving to a file

### DIFF
--- a/.github/workflows/cv-model-ci.yml
+++ b/.github/workflows/cv-model-ci.yml
@@ -1,0 +1,25 @@
+name: pr-cv-model
+
+on:
+  pull_request:
+    paths:
+      - 'pkgs/cv_model/**'
+      - '.github/workflows/cv-model-ci.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkgs/cv_model
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      run: |
+        pip install uv
+
+    - name: Run tests
+      run: |
+        uv sync --all-groups --all-extras --frozen
+        uv run pytest

--- a/StyloCV.code-workspace
+++ b/StyloCV.code-workspace
@@ -1,5 +1,9 @@
 {
   "folders": [
+      {
+      "name": "ci/cd",
+      "path": "./.github"
+    },
     {
       "name": "planning_docs",
       "path": "./docs"

--- a/pkgs/cv_model/src/cv_model/__init__.py
+++ b/pkgs/cv_model/src/cv_model/__init__.py
@@ -3,7 +3,8 @@ __all__ = [
     "RenderCtx",
     "get_default_resume",
     "generate",
+    "OutputFormat",
 ]
 
 from ._models import RenderCtx, Resume, get_default_resume
-from ._render import generate
+from ._render import OutputFormat, generate

--- a/pkgs/cv_model/src/cv_model/_render.py
+++ b/pkgs/cv_model/src/cv_model/_render.py
@@ -1,14 +1,12 @@
-import json
+import tempfile
 from pathlib import Path
-from typing import overload
+from typing import Literal, overload
 
 from jinja2 import Environment, FileSystemLoader
 
 import typst
 
 from . import _consts, _models
-
-__all__ = ["generate"]
 
 
 def _model2typ(
@@ -26,92 +24,86 @@ def _model2typ(
         f.write(template.render({"resume": model, "ctx": render_ctx}))
 
 
-def _model2output(
-    model: _models.Resume,
-    output_path: str | Path,
-    template_name: _consts.TemplateName,
-    render_ctx,
-) -> None:
-    custom_section_titles = [section.title for section in model.custom_sections]
-    for section_name in render_ctx.section_order:
-        if section_name in _models.DEFAULT_SECTIONS:
-            continue
-        if section_name not in custom_section_titles:
-            raise ValueError(
-                f"Section '{section_name}' not found in the resume model. "
-                + "Please check the section order."
-            )
+OutputFormat = Literal["typ", "pdf", "svg", "png", "html"]
+"""Supported output formats for CV generation.
 
-    _output_path = Path(output_path)
-    suffix = _output_path.name.split(".")[-1]
-    _output_path.parent.mkdir(parents=True, exist_ok=True)
-    if suffix == "typ":
-        _model2typ(model, template_name, _output_path, render_ctx)
-    elif suffix in ["pdf", "svg", "png", "html"]:
-        temp_path = _output_path.with_suffix(".typ")
-        _model2typ(model, template_name, temp_path, render_ctx)
-        try:
-            # File is already closed from the with block
-            typst.compile(str(temp_path), str(output_path), format=suffix)  # type: ignore
-        finally:
-            temp_path.unlink()
-    else:
-        raise ValueError(
-            "output_path must end with typ, pdf, svg, png, or html. "
-            + f"Got: {_output_path.name}"
-        )
+- typ: Typst source file
+- pdf: Portable Document Format
+- svg: Scalable Vector Graphics
+- png: Portable Network Graphics
+- html: HyperText Markup Language
+"""
 
 
 @overload
 def generate(
     src: _models.Resume,
     output_path: Path | str,
-    template_name: _consts.TemplateName,
+    output_format: OutputFormat,
+    template_name: _consts.TemplateName = "fantastic-cv",
     render_ctx: _models.RenderCtx = _models.RenderCtx(),
 ) -> None: ...
 
 
 @overload
 def generate(
-    src: str,
+    src: _models.Resume,
+    output_path: None,
+    output_format: OutputFormat,
+    template_name: _consts.TemplateName = "fantastic-cv",
+    render_ctx: _models.RenderCtx = _models.RenderCtx(),
+) -> bytes: ...
+
+
+@overload
+def generate(
+    src: Path | str,
     output_path: Path | str,
-    template_name: _consts.TemplateName,
+    output_format: OutputFormat,
+    template_name: _consts.TemplateName = "fantastic-cv",
     render_ctx: _models.RenderCtx = _models.RenderCtx(),
 ) -> None: ...
 
 
 @overload
 def generate(
-    src: Path,
-    output_path: Path | str,
-    template_name: _consts.TemplateName,
+    src: Path | str,
+    output_path: None,
+    output_format: OutputFormat,
+    template_name: _consts.TemplateName = "fantastic-cv",
     render_ctx: _models.RenderCtx = _models.RenderCtx(),
-) -> None: ...
+) -> bytes: ...
 
 
-def generate(src, output_path, template_name, render_ctx=_models.RenderCtx()) -> None:
-    """Generate a CV from a JSON string or file path.
+def generate(
+    src,
+    output_path,
+    output_format,
+    template_name: _consts.TemplateName = "fantastic-cv",
+    render_ctx=_models.RenderCtx(),
+) -> bytes | None:
+    """Generates a CV document from a Resume model or JSON file.
+
     Args:
-        src: The source JSON string or file path.
-        output_path: The output file path. Could be one of the following formats:
-            - typ: Typst file
-            - pdf: PDF file
-            - svg: SVG file
-            - png: PNG file
-            - html: HTML file
-        template_name: The name of the template to use.
-        render_ctx: The render context to use.
+        src: The content source, either as a Resume model or a path to a JSON file.
+        output_path: The path to save the generated document, or None to return bytes.
+        output_format: The desired output format (typ, pdf, svg, png, html).
+        template_name: The name of the template to use. Defaults to "fantastic-cv".
+        render_ctx: The rendering context with additional styling options.
+
+    Returns:
+        Bytes of the generated document if output_path is None, otherwise None.
     """
-    if not isinstance(src, _models.Resume):
-        path_maybe = Path(src)
-        if not (set(str(src)) & set(["{", "["])) and path_maybe.exists():
-            return generate(
-                path_maybe.read_text(encoding="utf-8"), output_path, template_name, render_ctx
-            )
-        parsed_content = json.loads(src)
-        model = _models.Resume.model_validate(parsed_content)
-    else:
+    if isinstance(src, (str, Path)):
+        _src = Path(src)
+        suffix = _src.suffix.lstrip(".")
+        if suffix != "json":
+            raise ValueError("src must be a json file.")
+        model = _models.Resume.model_validate_json(_src.read_text(encoding="utf-8"))
+    elif isinstance(src, _models.Resume):
         model = src
+    else:
+        raise ValueError("src must be either a Resume model or a path to a json file.")
 
     custom_section_titles = [section.title for section in model.custom_sections]
     for section_name in render_ctx.section_order:
@@ -123,9 +115,28 @@ def generate(src, output_path, template_name, render_ctx=_models.RenderCtx()) ->
                 + "Please check the section order."
             )
 
-    _model2output(
-        model=model,
-        output_path=output_path,
-        template_name=template_name,
-        render_ctx=render_ctx,
-    )
+    if output_format == "typ":
+        # This case doesn't make sense for in-memory generation
+        if output_path is None:
+            raise ValueError("output_path must be provided for typ output.")
+        _model2typ(model, template_name, output_path, render_ctx)
+        return None
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir) / "resume.typ"
+
+        _model2typ(model, template_name, temp_path, render_ctx)
+        # Compile to memory
+        result = typst.compile(str(temp_path), format=output_format)
+        if output_path is not None:
+            # If path is provided, write to it
+            _output_path = Path(output_path)
+            if not _output_path.name.endswith(output_format):
+                raise ValueError(
+                    f"output_path must end with {output_format}. Got: {output_path}"
+                )
+            _output_path.parent.mkdir(parents=True, exist_ok=True)
+            _output_path.write_bytes(result)
+            return None
+        # Otherwise, return the bytes
+        return result

--- a/pkgs/cv_model/tests/test_model.py
+++ b/pkgs/cv_model/tests/test_model.py
@@ -9,18 +9,32 @@ DATA_FOLDER = Path(__file__).parent / "data_files"
 
 def test_valid_resume_model():
     """Test the Resume model with valid data."""
-    with open(DATA_FOLDER / "valid_resume.json", "r", encoding="utf-8") as f:
-        content = f.read()
+    cv.Resume.model_validate_json(
+        (DATA_FOLDER / "valid_resume.json").read_text(encoding="utf-8")
+    )
 
-    cv.Resume.model_validate_json(content)
 
-
-def test_render_json(tmp_path: Path):
+def test_render_file_from_json(tmp_path: Path):
     """Test the rendering of a JSON resume."""
     cv.generate(
-        DATA_FOLDER / "example_resume.json", tmp_path / "json_output.pdf", "fantastic-cv"
+        src=DATA_FOLDER / "example_resume.json",
+        output_path=tmp_path / "json_output.pdf",
+        output_format="pdf",
+        template_name="fantastic-cv",
     )
     assert (tmp_path / "json_output.pdf").exists()
+
+
+def test_render_bytes_from_json():
+    """Test the rendering of a JSON resume."""
+    rendered_content = cv.generate(
+        src=DATA_FOLDER / "example_resume.json",
+        output_path=None,
+        output_format="pdf",
+        template_name="fantastic-cv",
+    )
+    assert rendered_content is not None
+    assert isinstance(rendered_content, bytes)
 
 
 def test_load_json():
@@ -29,8 +43,67 @@ def test_load_json():
     assert loaded == cv.get_default_resume()
 
 
+def test_invalid_src_file_extension():
+    """Test that an invalid src file extension raises a ValueError."""
+    with pytest.raises(ValueError):
+        cv.generate(
+            src="some_file.txt",  # Invalid file extension
+            output_path=None,
+            output_format="pdf",
+            template_name="fantastic-cv",
+        )
+
+
+def test_invalid_src_type():
+    """Test that an invalid src type (e.g., int) raises a ValueError."""
+    with pytest.raises(ValueError):
+        cv.generate(
+            src=12345,  # type: ignore
+            output_path=None,
+            output_format="pdf",
+            template_name="fantastic-cv",
+        )
+
+
 @pytest.mark.parametrize(
     "ext", ["typ", "pdf"]
 )  # svg and png does not support multi-page yet ...
-def test_generate(tmp_path: Path, ext: str) -> None:
-    cv.generate(cv.get_default_resume(), tmp_path / f"test.{ext}", "fantastic-cv")
+def test_render_file_from_model(tmp_path: Path, ext: cv.OutputFormat) -> None:
+    cv.generate(
+        cv.get_default_resume(),
+        output_path=tmp_path / f"test.{ext}",
+        output_format=ext,
+        template_name="fantastic-cv",
+    )
+    assert (tmp_path / f"test.{ext}").exists()
+
+
+def test_render_bytes_from_model():
+    """Test the rendering of a Resume model to bytes."""
+    rendered_content = cv.generate(
+        cv.get_default_resume(),
+        output_path=None,
+        output_format="pdf",
+        template_name="fantastic-cv",
+    )
+    assert rendered_content is not None
+    assert isinstance(rendered_content, bytes)
+
+
+def test_inconsistent_output_path_and_format(tmp_path: Path):
+    """Test that inconsistent output_path and output_format raises a ValueError."""
+    with pytest.raises(ValueError):
+        cv.generate(
+            cv.get_default_resume(),
+            output_path=tmp_path / "test.png",
+            output_format="pdf",
+            template_name="fantastic-cv",
+        )
+
+    with pytest.raises(ValueError):
+        cv.generate(
+            cv.get_default_resume(),
+            output_path=None,
+            output_format="typ",
+            template_name="fantastic-cv",
+        )

--- a/pkgs/docs/cv_model/docs/api/api.md
+++ b/pkgs/docs/cv_model/docs/api/api.md
@@ -4,4 +4,6 @@
 
 ::: cv_model.get_default_resume
 
+::: cv_model.OutputFormat
+
 ::: cv_model.generate


### PR DESCRIPTION
This PR enhances the cv_model.generate() function to support returning PDF bytes directly in addition to saving to a file. This enables in-memory generation for use cases like web APIs where file I/O is unnecessary.

# Key changes:

- Added output_format parameter to explicitly specify the desired output format ("pdf", "svg", "png", "html")
- Modified generate() to return bytes when output_path=None, or None when writing to a file
- Refactored the implementation to use typst.compile() for in-memory compilation with a temporary .typ file
- Added comprehensive test coverage for both file-based and bytes-based generation workflows